### PR TITLE
Use old diff calc to verify old blocks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1331,7 +1331,7 @@ unsigned int static GetNextWorkRequired_V1(const CBlockIndex* pindexLast, const 
 
 	// Start at difficulty of 1
     if (pindexLast->nHeight+1 < nAveragingInterval)
-        return bnStartingDifficulty.GetCompact();
+        return nProofOfWorkLimit;
 
     // Only change once per interval
     if ((pindexLast->nHeight+1) % nInterval != 0)


### PR DESCRIPTION
Unable to verify blocks at all because it is using the starting diff, which for any blocks other than genesis, will fail.